### PR TITLE
Changed command name to clear confusion

### DIFF
--- a/scripts/register_commands.ts
+++ b/scripts/register_commands.ts
@@ -11,7 +11,7 @@ const CLIENT_ID = process.env.CLIENT_ID!;
 const commands: RESTPostAPIApplicationCommandsJSONBody[] = [
   {
     type: ApplicationCommandType.User,
-    name: "Pay with Tabby",
+    name: "Issue IOU with TabbyPay",
   },
   {
     type: ApplicationCommandType.User,

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -24,7 +24,7 @@ export async function handlePay(ix: UserContextMenuCommandInteraction) {
 
   const modal = new ModalBuilder() //
     .setCustomId(`${ix.id}-modal`)
-    .setTitle(`Paying @${ix.targetUser.tag}`);
+    .setTitle(`Issuing IOU to @${ix.targetUser.tag}`);
 
   const amountInput = new TextInputBuilder()
     .setCustomId(`${ix.id}-amountInput`)

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -13,12 +13,12 @@ import * as db from "./database";
 
 export async function handlePay(ix: UserContextMenuCommandInteraction) {
   if (ix.user.id === ix.targetUser.id) {
-    await ix.reply({ content: "You can't pay yourself!", ephemeral: true });
+    await ix.reply({ content: "You can't owe yourself!", ephemeral: true });
     return;
   }
 
   if (ix.targetUser.bot) {
-    await ix.reply({ content: "You can't pay a bot!", ephemeral: true });
+    await ix.reply({ content: "You can't owe a bot!", ephemeral: true });
     return;
   }
 
@@ -104,7 +104,7 @@ export async function handlePay(ix: UserContextMenuCommandInteraction) {
   });
 
   const embed = new EmbedBuilder()
-    .setTitle("Payment Complete")
+    .setTitle("Debt Issuance Complete")
     .setColor("#3de643")
     .setTimestamp()
     .setDescription("The transaction completed successfully.")

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,7 +15,7 @@ bot.on("interactionCreate", async (ix) => {
   if (ix.isUserContextMenuCommand()) {
     const normalizedName = ix.commandName.toLowerCase().replace(/[\s-]+/g, "-");
 
-    if (normalizedName == "pay-with-tabby") {
+    if (normalizedName == "issue-iou-with-tabbypay") {
       await handlePay(ix);
     } else if (normalizedName == "view-tabby-balances") {
       await handleViewBalances(ix);


### PR DESCRIPTION
The command "Pay with Tabby" was confusing, as well as various other prompts and displays that used the term "pay". These were changed to use the words "debt" or "IOU". 